### PR TITLE
Matching windowTitle with a regex and continue if the exec's PID is missing.

### DIFF
--- a/Sonar.AutoSwitch/Services/AutoSwitchService.cs
+++ b/Sonar.AutoSwitch/Services/AutoSwitchService.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using Avalonia.Logging;
 using Sonar.AutoSwitch.ViewModels;
 
 namespace Sonar.AutoSwitch.Services;
@@ -48,11 +50,11 @@ public class AutoSwitchService
                     autoSwitchProfileViewModels.Concat(AutoSwitchProfilesDatabase.Instance.GithubProfiles);
             }
 
-            AutoSwitchProfileViewModel? autoSwitchProfileViewModel =
-                autoSwitchProfileViewModels.FirstOrDefault(p =>
+            AutoSwitchProfileViewModel? autoSwitchProfileViewModel = autoSwitchProfileViewModels.FirstOrDefault(p =>
                     (string.IsNullOrEmpty(p.ExeName) ||
                      string.Equals(p.ExeName, windowExeName, StringComparison.OrdinalIgnoreCase)) &&
-                    (string.IsNullOrEmpty(p.Title) || e.Title.Contains(p.Title, StringComparison.OrdinalIgnoreCase)));
+                    p.MatchTitle(e.Title));
+
             SonarGamingConfiguration? sonarGamingConfiguration = autoSwitchProfileViewModel?.SonarGamingConfiguration;
             sonarGamingConfiguration ??= _homeViewModel.DefaultSonarGamingConfiguration;
             if (string.IsNullOrEmpty(sonarGamingConfiguration.Id) ||

--- a/Sonar.AutoSwitch/Services/Win32/Win32WindowEventManager.cs
+++ b/Sonar.AutoSwitch/Services/Win32/Win32WindowEventManager.cs
@@ -62,12 +62,15 @@ public class Win32WindowEventManager : IWindowEventManager
         int idChild, uint dwEventThread, uint dwmsEventTime)
     {
         string windowTitle = GetWindowTitle(hwnd);
-        if (GetWindowThreadProcessId(hwnd, out var pid) == 0)
-            return;
         string? exeName = null;
+        if (GetWindowThreadProcessId(hwnd, out var pid) == 0)
+        {
+            OnForegroundWindowChanged(new WindowInfo(exeName, windowTitle));
+            return;
+        }
         try
         {
-            using var processById = Process.GetProcessById((int) pid);
+            using var processById = Process.GetProcessById((int)pid);
             string? fileName = processById.MainModule?.FileName;
             if (string.IsNullOrEmpty(fileName))
                 return;

--- a/Sonar.AutoSwitch/ViewModels/AutoSwitchProfileViewModel.cs
+++ b/Sonar.AutoSwitch/ViewModels/AutoSwitchProfileViewModel.cs
@@ -1,11 +1,14 @@
 using Sonar.AutoSwitch.Services;
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 namespace Sonar.AutoSwitch.ViewModels;
 
 public class AutoSwitchProfileViewModel : ViewModelBase
 {
+    private static readonly RegexOptions REGEX_OPTIONS = RegexOptions.IgnoreCase;
     private string _exeName = "MyGame";
     private string _title = "";
+    private Regex _titleRegex = new Regex("", REGEX_OPTIONS);
     private SonarGamingConfiguration _sonarGamingConfiguration = new(null, "Unset");
 
     public string Title
@@ -14,10 +17,16 @@ public class AutoSwitchProfileViewModel : ViewModelBase
         set
         {
             if (value == _title) return;
-            _title = value;
+            _title = value ??= "";
+            _titleRegex = new Regex(_title, REGEX_OPTIONS);
             OnPropertyChanged();
             OnPropertyChanged(nameof(DisplayName)); // Notify that DisplayName has changed
         }
+    }
+
+    public bool MatchTitle(string title)
+    {
+        return _titleRegex.IsMatch(title);
     }
 
     public string ExeName


### PR DESCRIPTION
Hello 👋🏻 

This permit the use of a regex on the Title so you can catch windows with special characters.
Then, it fix a scenario when the app can't retrieve the PID of a game and stopped when it could continue with the Title only.

Fixing these issue :
https://github.com/adirh3/Sonar.AutoSwitch/issues/28

Answer to those issue :
https://github.com/adirh3/Sonar.AutoSwitch/issues/30
https://github.com/adirh3/Sonar.AutoSwitch/issues/23

PS : My last PR was think so you can have a nice looking list of profile, regex won't help so I will think of a way to do it !

Hope you like this PR ! (I'm new, I don't know who is responsible of creating a release after a merge, but I think it would be nice)

Mativec