### PR TITLE
feat: Setting to focus the window scan on 1 display

### DIFF
--- a/Sonar.AutoSwitch/Pages/Settings.axaml
+++ b/Sonar.AutoSwitch/Pages/Settings.axaml
@@ -38,7 +38,8 @@
         <ui:SettingsExpander.Footer>
           <ScrollViewer Height="120" VerticalScrollBarVisibility="Auto">
             <ComboBox Items="{Binding AvailableMonitors}"
-                      SelectedItem="{Binding SelectedMonitor}"
+                      SelectedItem="{Binding SelectedMonitor, Mode=TwoWay}"
+                      SelectedIndex="0"
                       Width="200"/>
           </ScrollViewer>
         </ui:SettingsExpander.Footer>

--- a/Sonar.AutoSwitch/Pages/Settings.axaml
+++ b/Sonar.AutoSwitch/Pages/Settings.axaml
@@ -32,6 +32,17 @@
                 <ToggleSwitch IsChecked="{Binding UseGithubConfigs}" />
             </ui:SettingsExpander.Footer>
         </ui:SettingsExpander>
+      <ui:SettingsExpander IconSource="🖥️" Header="Select Display" IsExpanded="True"
+                         Description="Choose which monitor Sonar Auto Switch should focus"
+                         IsClickEnabled="False">
+        <ui:SettingsExpander.Footer>
+          <ScrollViewer Height="120" VerticalScrollBarVisibility="Auto">
+            <ComboBox Items="{Binding AvailableMonitors}"
+                      SelectedItem="{Binding SelectedMonitor}"
+                      Width="200"/>
+          </ScrollViewer>
+        </ui:SettingsExpander.Footer>
+      </ui:SettingsExpander>
     </StackPanel>
 
 </UserControl>

--- a/Sonar.AutoSwitch/Services/AutoSwitchService.cs
+++ b/Sonar.AutoSwitch/Services/AutoSwitchService.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
+using Avalonia.Logging;
 using Sonar.AutoSwitch.ViewModels;
 
 namespace Sonar.AutoSwitch.Services;
@@ -48,11 +50,11 @@ public class AutoSwitchService
                     autoSwitchProfileViewModels.Concat(AutoSwitchProfilesDatabase.Instance.GithubProfiles);
             }
 
-            AutoSwitchProfileViewModel? autoSwitchProfileViewModel =
-                autoSwitchProfileViewModels.FirstOrDefault(p =>
+            AutoSwitchProfileViewModel? autoSwitchProfileViewModel = autoSwitchProfileViewModels.FirstOrDefault(p =>
                     (string.IsNullOrEmpty(p.ExeName) ||
                      string.Equals(p.ExeName, windowExeName, StringComparison.OrdinalIgnoreCase)) &&
-                    (string.IsNullOrEmpty(p.Title) || e.Title.Contains(p.Title, StringComparison.OrdinalIgnoreCase)));
+                    p.MatchTitle(e.Title));
+
             SonarGamingConfiguration? sonarGamingConfiguration = autoSwitchProfileViewModel?.SonarGamingConfiguration;
             sonarGamingConfiguration ??= _homeViewModel.DefaultSonarGamingConfiguration;
             if (string.IsNullOrEmpty(sonarGamingConfiguration.Id) ||

--- a/Sonar.AutoSwitch/Services/MonitorOption.cs
+++ b/Sonar.AutoSwitch/Services/MonitorOption.cs
@@ -1,19 +1,45 @@
 ﻿using Avalonia.Platform;
+using System;
 
 namespace Sonar.AutoSwitch.Services
 {
-    public class MonitorOption
+    public class MonitorOption : IEquatable<MonitorOption>
     {
+        private static int IdCount = 1;
+        public int Id { get; }
         public string Name { get; }
         public Screen? Screen { get; }
 
         public MonitorOption(string name, Screen? screen)
         {
+            Id = IdCount++;
             Name = name;
             Screen = screen;
         }
 
         public override string ToString() => Name;
-    }
 
+        public bool Equals(MonitorOption? other)
+        {
+            if (ReferenceEquals(other, null)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return Id == other.Id;
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is MonitorOption other && Equals(other);
+        }
+
+        public override int GetHashCode() => Id.GetHashCode();
+
+        public static bool operator ==(MonitorOption? left, MonitorOption? right)
+        {
+            if (ReferenceEquals(left, right)) return true;
+            if (ReferenceEquals(left, null) || ReferenceEquals(right, null)) return false;
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(MonitorOption? left, MonitorOption? right) => !(left == right);
+    }
 }

--- a/Sonar.AutoSwitch/Services/MonitorOption.cs
+++ b/Sonar.AutoSwitch/Services/MonitorOption.cs
@@ -1,0 +1,19 @@
+﻿using Avalonia.Platform;
+
+namespace Sonar.AutoSwitch.Services
+{
+    public class MonitorOption
+    {
+        public string Name { get; }
+        public Screen? Screen { get; }
+
+        public MonitorOption(string name, Screen? screen)
+        {
+            Name = name;
+            Screen = screen;
+        }
+
+        public override string ToString() => Name;
+    }
+
+}

--- a/Sonar.AutoSwitch/Services/Win32/Win32WindowEventManager.cs
+++ b/Sonar.AutoSwitch/Services/Win32/Win32WindowEventManager.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Sonar.AutoSwitch.ViewModels;
+using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
@@ -57,17 +58,21 @@ public class Win32WindowEventManager : IWindowEventManager
     {
         ForegroundWindowChanged?.Invoke(this, e);
     }
-
     private void WindowEventCallback(nint hWinEventHook, uint eventType, nint hwnd, int idObject,
         int idChild, uint dwEventThread, uint dwmsEventTime)
     {
         string windowTitle = GetWindowTitle(hwnd);
+        var focusedScreen = StateManager.Instance.GetOrLoadState<SettingsViewModel>().SelectedMonitor;
+
+        if (focusedScreen?.Screen != null && !MonitorHelper.AreSameScreen(focusedScreen.Screen, MonitorHelper.GetScreenFromHwnd(hwnd)))
+            return;
         if (GetWindowThreadProcessId(hwnd, out var pid) == 0)
             return;
         string? exeName = null;
         try
         {
-            using var processById = Process.GetProcessById((int) pid);
+
+            using var processById = Process.GetProcessById((int)pid);
             string? fileName = processById.MainModule?.FileName;
             if (string.IsNullOrEmpty(fileName))
                 return;

--- a/Sonar.AutoSwitch/Services/Win32/Win32WindowEventManager.cs
+++ b/Sonar.AutoSwitch/Services/Win32/Win32WindowEventManager.cs
@@ -62,12 +62,15 @@ public class Win32WindowEventManager : IWindowEventManager
         int idChild, uint dwEventThread, uint dwmsEventTime)
     {
         string windowTitle = GetWindowTitle(hwnd);
-        if (GetWindowThreadProcessId(hwnd, out var pid) == 0)
-            return;
         string? exeName = null;
+        if (GetWindowThreadProcessId(hwnd, out var pid) == 0)
+        {
+            OnForegroundWindowChanged(new WindowInfo(exeName, windowTitle));
+            return;
+        }
         try
         {
-            using var processById = Process.GetProcessById((int) pid);
+            using var processById = Process.GetProcessById((int)pid);
             string? fileName = processById.MainModule?.FileName;
             if (string.IsNullOrEmpty(fileName))
                 return;

--- a/Sonar.AutoSwitch/ViewModels/AutoSwitchProfileViewModel.cs
+++ b/Sonar.AutoSwitch/ViewModels/AutoSwitchProfileViewModel.cs
@@ -1,11 +1,14 @@
 using Sonar.AutoSwitch.Services;
 using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
 namespace Sonar.AutoSwitch.ViewModels;
 
 public class AutoSwitchProfileViewModel : ViewModelBase
 {
+    private static readonly RegexOptions REGEX_OPTIONS = RegexOptions.IgnoreCase;
     private string _exeName = "MyGame";
     private string _title = "";
+    private Regex _titleRegex = new Regex("", REGEX_OPTIONS);
     private SonarGamingConfiguration _sonarGamingConfiguration = new(null, "Unset");
 
     public string Title
@@ -14,10 +17,16 @@ public class AutoSwitchProfileViewModel : ViewModelBase
         set
         {
             if (value == _title) return;
-            _title = value;
+            _title = value ??= "";
+            _titleRegex = new Regex(_title, REGEX_OPTIONS);
             OnPropertyChanged();
             OnPropertyChanged(nameof(DisplayName)); // Notify that DisplayName has changed
         }
+    }
+
+    public bool MatchTitle(string title)
+    {
+        return _titleRegex.IsMatch(title);
     }
 
     public string ExeName

--- a/Sonar.AutoSwitch/ViewModels/SettingsViewModel.cs
+++ b/Sonar.AutoSwitch/ViewModels/SettingsViewModel.cs
@@ -4,12 +4,14 @@ using Sonar.AutoSwitch.Services;
 using Sonar.AutoSwitch.Services.Win32;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Text.Json.Serialization;
 namespace Sonar.AutoSwitch.ViewModels;
 
 public class SettingsViewModel : ViewModelBase
 {
     private bool _enabled = true;
     private bool _startAtStartup = true;
+    private int? _selectedMonitorId;
     private MonitorOption? _selectedMonitor;
 
     public SettingsViewModel()
@@ -31,7 +33,14 @@ public class SettingsViewModel : ViewModelBase
         AvailableMonitors = new ObservableCollection<MonitorOption>(monitors);
         Dispatcher.UIThread.Post(() =>
         {
-            SelectedMonitor = monitors[0];
+            if (_selectedMonitorId.HasValue)
+            {
+                SelectedMonitor = monitors.Find(m => m.Id == _selectedMonitorId.Value) ?? monitors[0];
+            }
+            else
+            {
+                SelectedMonitor = monitors[0];
+            }
         });
     }
 
@@ -61,8 +70,21 @@ public class SettingsViewModel : ViewModelBase
 
     public bool UseGithubConfigs { get; set; } = true;
 
+    public int? SelectedMonitorId
+    {
+        get => _selectedMonitorId;
+        set
+        {
+            if (_selectedMonitorId == value) return;
+            _selectedMonitorId = value;
+            OnPropertyChanged();
+        }
+    }
+
+    [JsonIgnore]
     public ObservableCollection<MonitorOption> AvailableMonitors { get; }
 
+    [JsonIgnore]
     public MonitorOption? SelectedMonitor
     {
         get => _selectedMonitor;
@@ -70,6 +92,7 @@ public class SettingsViewModel : ViewModelBase
         {
             if (_selectedMonitor == value) return;
             _selectedMonitor = value;
+            _selectedMonitorId = value?.Id;
             OnPropertyChanged();
         }
     }

--- a/Sonar.AutoSwitch/ViewModels/SettingsViewModel.cs
+++ b/Sonar.AutoSwitch/ViewModels/SettingsViewModel.cs
@@ -1,5 +1,8 @@
-﻿using Sonar.AutoSwitch.Services;
+﻿using Avalonia.Controls;
+using Sonar.AutoSwitch.Services;
 using Sonar.AutoSwitch.Services.Win32;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Sonar.AutoSwitch.ViewModels;
 
@@ -7,6 +10,29 @@ public class SettingsViewModel : ViewModelBase
 {
     private bool _enabled = true;
     private bool _startAtStartup = true;
+    private MonitorOption? _selectedMonitor;
+
+    public SettingsViewModel()
+    {
+        var screens = new Window().Screens.All;
+        var monitors = new List<MonitorOption>();
+
+        for (int i = 0; i < screens.Count; i++)
+        {
+            var screen = screens[i];
+            // Create a name, marking the primary screen
+            var name = $"Monitor {i + 1} ({screen.Bounds.Width}x{screen.Bounds.Height})";
+            if (screen.IsPrimary)
+                name += " [Primary]";
+
+            monitors.Add(new MonitorOption(name, screen));
+        }
+
+        // Default to "Any"
+        monitors.Insert(0, new MonitorOption("Any", null));
+        AvailableMonitors = new ObservableCollection<MonitorOption>(monitors);
+        SelectedMonitor = AvailableMonitors[0];
+    }
 
     public bool Enabled
     {
@@ -33,6 +59,19 @@ public class SettingsViewModel : ViewModelBase
     }
 
     public bool UseGithubConfigs { get; set; } = true;
+
+    public ObservableCollection<MonitorOption> AvailableMonitors { get; }
+
+    public MonitorOption? SelectedMonitor
+    {
+        get => _selectedMonitor;
+        set
+        {
+            if (_selectedMonitor == value) return;
+            _selectedMonitor = value;
+            OnPropertyChanged();
+        }
+    }
 
     protected override void OnPropertyChanged(string? propertyName = null)
     {

--- a/Sonar.AutoSwitch/ViewModels/SettingsViewModel.cs
+++ b/Sonar.AutoSwitch/ViewModels/SettingsViewModel.cs
@@ -1,9 +1,9 @@
 ﻿using Avalonia.Controls;
+using Avalonia.Threading;
 using Sonar.AutoSwitch.Services;
 using Sonar.AutoSwitch.Services.Win32;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-
 namespace Sonar.AutoSwitch.ViewModels;
 
 public class SettingsViewModel : ViewModelBase
@@ -15,7 +15,7 @@ public class SettingsViewModel : ViewModelBase
     public SettingsViewModel()
     {
         var screens = new Window().Screens.All;
-        var monitors = new List<MonitorOption>();
+        List<MonitorOption> monitors = new() { new MonitorOption("Any", null) };
 
         for (int i = 0; i < screens.Count; i++)
         {
@@ -28,10 +28,11 @@ public class SettingsViewModel : ViewModelBase
             monitors.Add(new MonitorOption(name, screen));
         }
 
-        // Default to "Any"
-        monitors.Insert(0, new MonitorOption("Any", null));
         AvailableMonitors = new ObservableCollection<MonitorOption>(monitors);
-        SelectedMonitor = AvailableMonitors[0];
+        Dispatcher.UIThread.Post(() =>
+        {
+            SelectedMonitor = monitors[0];
+        });
     }
 
     public bool Enabled

--- a/Sonar.AutoSwitch/ViewModels/SettingsViewModel.cs
+++ b/Sonar.AutoSwitch/ViewModels/SettingsViewModel.cs
@@ -23,7 +23,7 @@ public class SettingsViewModel : ViewModelBase
         {
             var screen = screens[i];
             // Create a name, marking the primary screen
-            var name = $"Monitor {i + 1} ({screen.Bounds.Width}x{screen.Bounds.Height})";
+            var name = $"Display {i + 1} ({screen.Bounds.Width}x{screen.Bounds.Height})";
             if (screen.IsPrimary)
                 name += " [Primary]";
 


### PR DESCRIPTION
Hello 👋🏻 

Using this tool with two display, one on the game and another on Discord, I find it annoying that the game's sonar preset change to the default one when I'm alt-tabbing to Discord on my 2nd screen.

So I added a setting to select a display for the tool to foxy it's scan onto.

PS : I would appreciate if you could look at [my last PR](https://github.com/adirh3/Sonar.AutoSwitch/pull/35), as it fixed some issues people have with this tool.

Hope you like this PR !

Mativec